### PR TITLE
New post subdirs

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -649,8 +649,13 @@ get_author <- function() {
 get_subdirs <- function() {
   user_option <- getOption('blogdown.subdir', '')
 
+  exclude_rendered <- function(dirs) {
+    dirs[!grepl("_(files|cache)$", dirs)]
+  }
+
   base_subdirs <- list.dirs(file.path(site_root(), "content"),
                             full.names = FALSE, recursive = FALSE)
+  base_subdirs <- exclude_rendered(base_subdirs)
 
   if (!length(base_subdirs)) {
     # No directories under content/
@@ -673,7 +678,9 @@ get_subdirs <- function() {
     blogdown_files <- blogdown_files[!grepl("index", blogdown_files)]
     if (length(blogdown_files)) next
 
-    subdir_dirs <- list.dirs(subdir_path, full.names = FALSE, recursive = FALSE)
+    subdir_dirs <- exclude_rendered(
+      list.dirs(subdir_path, full.names = FALSE, recursive = FALSE)
+    )
     if (length(subdir_dirs)) {
       subdir_dirs <- file.path(subdir, subdir_dirs)
       names(subdir_dirs) <- basename(subdir_dirs)


### PR DESCRIPTION
Hi @maelle! Loving the changes to the new post addin, but I realized that I have a possibly unusual but maybe not uncommon setup where I keep posts in subfolders by year under `blog/`, e.g.

```
content
├── blog
│   ├── 2012
│   ├── 2013
│   ├── 2014
│   ├── 2017
│   ├── 2018
│   └── 2019
└── ... other folders ...
```

I made a few changes to `get_subdirs()` that will recurse one  level if a subdir of `content` contains folders (but not blog posts other than `index.*`). In the end, it looks something like this:

![image](https://user-images.githubusercontent.com/5420529/75833619-93cee780-5d87-11ea-8988-244ebbc273de.png)

You can still add a new folder that isn't in the list. And it also makes sure that `blogdown.subdir` option is available even if it doesn't exist yet.

I know a PR to a PR is a little unusual, but like you said, it was easier to communicate and work out my ideas by implementing them 😄 